### PR TITLE
3 UN documents converted

### DIFF
--- a/sources/ECE_AGAT_2020_INF1.adoc
+++ b/sources/ECE_AGAT_2020_INF1.adoc
@@ -1,0 +1,136 @@
+= Annotated provisional agenda
+:doctype: agenda
+:committee: Centre for Trade Facilitation and Electronic Business
+:status: published
+:copyright-year: 2019
+:session: 1
+:session-date: Geneva, 30 January 2020
+:item-number: 1 of the provisional agenda
+:agenda-id: ECE/AGAT/2020/INF.1
+:item-name: Advisory Group on Advanced Technologies
+:revdate: 30 January 2020
+:language: en
+:distribution: General
+:mn-document-class: un
+:mn-output-extensions: xml,html,doc,rxl
+:docfile: ECE_AGAT_2020_INF1.adoc
+:local-cache-only:
+:data-uri-image:
+
+
+== Provisional agenda footnote:[For reasons of economy, delegates are requested to bring copies of all relevant documents to the session. There will be no documentation available in the conference room. Before the session, documents may be downloaded from the UNECE website (http://www.unece.org/uncefact/atag-1stsession-2020).], footnote:[All delegates are requested to complete the online registration form available on the UNECE website (http://www.unece.org/uncefact/atag-1stsession-2020). Upon arrival at the Palais des Nations, delegates should obtain an identification badge at the UNOG Security and Safety Section, located at the Pregny Gate (14, Av. de la Paix). In case of difficulty, please contact the secretariat by telephone (ext. 73254). For a map of the Palais des Nations and other useful information, see the website: https://www.unece.org/meetings/practical.html.]
+
+. Adoption of the agenda
+
+. Appointment of Chair and Vice-Chairs
+
+. Panel on Transformative Technologies in Trade and Logistics
+
+. Panel discussion on obstacles and challenges
+
+. Vision, Mission and Programme of Work
+
+. Future work
+
+. Other business
+
+. Adoption of decisions and the report of the first session
+
+
+== Annotations
+
+=== Opening
+
+The session will be opened by the Director of the Economic Cooperation and Trade Division of the United Nations Economic Commission for Europe (UNECE).
+
+=== Item 1. Adoption of the agenda
+
+The secretariat will present the draft agenda for adoption.
+
+_Documentation_:
+
+Informal document ECE/AGAT/2020/INF.1
+
+
+=== Item 2. Appointment of the Officers
+
+In line with its Mandate and Terms of Reference (ECE/TRADE/C/CEFACT/2019/22/Rev.1), the Advisory Group will appoint its Chair and eventually Vice Chair (s) in accordance with the Guidelines for the establishment and functioning of teams of specialists (ECE/EX/2/Rev.1).
+
+Candidates must be physically present and will be given an opportunity to present themselves. Official country delegates (one officially appointed delegate per country) who are physically present may participate in the election.
+
+_Documentation_:
+
+ECE/TRADE/C/CEFACT/2019/22/Rev.1 +
+ECE/EX/2/Rev.1
+
+=== Item 3. Panel on Transformative Technologies in Trade and Logistics
+
+Managers and high-level experts from the public and private sectors who are involved in technology implementation will make presentations on the potential of specific technologies in trade and logistics as well as presenting use cases where the implementation challenges will be highlighted.  The technologies which will be covered include: the Internet of Things, Big Data, Artificial Intelligence (AI) and Machine Learning, Blockchain and Distributed Ledger Technology (DLT) and Interoperability Tools such as Application Programming Interfaces (APIs).
+
+_Documentation_:
+
+ECE/TRADE/C/CEFACT/2019/8 +
+ECE/TRADE/C/CEFACT/2019/9 +
+ECE/TRADE/C/CEFACT/2019/10 +
+ECE/TRADE/C/CEFACT/2019/27 +
+ECE/TRADE/C/CEFACT/2019/INF.3 +
+ECE/TRADE/C/CEFACT/2018/9 +
+ECE/TRADE/C/CEFACT/2018/25 +
+http://www.unece.org/index.php?id=51234 +
+http://www.unece.org/index.php?id=51232
+
+=== Item 4. Panel discussion on obstacles and challenges
+
+Representatives from the public and private sectors as well as international organizations will discuss the principle challenges, implementations obstacles, and lessons learned from the implementation of new technologies.
+
+=== Item 5. Vision, Mission and Program of Work
+
+The draft vision and mission statement, summarizing the overall goals and methods by which to achieve them will be presented for discussion and the final version approved.
+
+The draft Programme of work of the Advisory Group on Advanced Technologies in Trade and Logistics for 2020-2021, which was prepared by the secretariat, will be presented to the Group for discussion and the final version approved.
+
+_Documentation:_	
+
+ECE/TRADE/C/CEFACT/2019/22/Rev.1 +
+ECE/AGAT/2020/INF.3 +
+ECE/AGAT/2020/INF.4
+
+=== Item 6. Future work
+
+The Group will discuss its future work, including the specific activities to be undertaken during the coming year.
+
+=== Item 7. Other business
+
+Experts will be invited to raise other issues not previously addressed during the session.
+
+=== Item 8. Adoption of decisions and the report of the first session
+
+Experts will be invited to adopt the report of the session.
+
+_Documentation_:
+
+ECE/AGAT/2020/INF.2
+
+*Closing*
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/sources/ECE_TRADE_C_CEFACT_2019_22_REV1.adoc
+++ b/sources/ECE_TRADE_C_CEFACT_2019_22_REV1.adoc
@@ -1,0 +1,95 @@
+= Mandate and Terms of Reference of the Advisory Group on Advanced Technologies in Trade and Logistics
+:doctype: terms-of-reference
+:committee: Centre for Trade Facilitation and Electronic Business
+:status: published
+:copyright-year: 2019
+:session: 25
+:session-date: Geneva, 8-9 April 2019
+:item-number: 8 of the provisional agenda
+:agenda-id: ECE/TRADE/C/CEFACT/2019/22/Rev.1
+:item-name: United Nations Centre for Trade Facilitation and Electronic Business (UN/CEFACT) structure, mandate, terms of reference and procedures
+:revdate: 8 April 2019
+:language: en
+:distribution: General
+:mn-document-class: un
+:mn-output-extensions: xml,html,doc,rxl
+:docfile: ECE_TRADE_C_CEFACT_2019_22_REV1.adoc
+:local-cache-only:
+:data-uri-image:
+
+
+[abstract]
+== Summary
+
+At the Hangzhou Forum of the United Nations Centre for Trade Facilitation and Electronic Business (UN/CEFACT) in October 2018, the establishment of an Advisory Group was proposed to advise and support the United Nations Economic Commission for Europe (UNECE) Secretariat and UN/CEFACT on advanced technologies in the international supply chain. The technologies in question include blockchain footnote:[In this paper, the term blockchain refers to/includes all Distributed Ledger Technologies (DLT).], Internet of Things (IoT), Artificial Intelligence (AI) and Application Programming Interfaces (API) - the most recent areas of rapid development in trade facilitation and electronic business.
+
+Document ECE/TRADE/C/CEFACT/2019/22/Rev.1 is submitted by the UN/CEFACT Bureau to the twenty-fifth session of the Plenary for decision.
+
+
+== Background
+
+Based on discussions in the eGovernment Domain and Blockchain Whitepaper Project Team meetings during the United Nations Centre for Trade Facilitation and Electronic Business (UN/CEFACT) Forum in October 2018, the establishment of an Advisory Group was proposed to the Bureau in order to advise and support the UNECE secretariat and UN/CEFACT on advanced technologies in trade facilitation and electronic business. The technologies in question include blockchain1, Internet of Things (IoT), and Artificial Intelligence (AI) - the most recent areas of rapid development in the international supply chain.
+
+== Objectives and activities
+
+The purpose of the Advisory Group is to advise on advanced technologies such as blockchain and IoT, as well as implementation challenges (such as regulatory obstacles). This includes the potential impact of these technologies on standards, services and everyday operations.
+
+To support UN/CEFACT in achieving this objective, the Advisory Group will:
+
+. Monitor the business needs related to these technologies and how they relate back to UN/CEFACT and its deliverables;
+
+. Support dialogue with key external stakeholders;
+
+. Provide advice and expertise on implementation requirements and challenges;
+
+. Identify new work items which will support the role of UN/CEFACT and its deliverables in the context of these technologies;
+
+. Preparing synopses of good practices on selected issues within the Group's mandate for discussion and endorsement by the Bureau; and
+
+. Provide support to senior managers on advanced technology issues, especially in the context of how these can be used with UN/CEFACT standards and UNECE recommendations.
+
+Under the guidance of the UNECE secretariat and within the framework of the UN/CEFACT "`Terms of Reference for Liaison with other Organizations`" (ECE/TRADE/C/CEFACT/2016-14), the Advisory Group may invite the participation of other organizations actively exploring the applications of this technology or their membership,  including the United Nations Office for Project Services (UNOPS), the World Food Programme (WFP), the United Nations Development Programme (UNDP), the World Bank, the International Monetary Fund (IMF), the Organization for Economic Cooperation and Development (OECD), the World Economic Forum (WEF), and other relevant standards development organizations.
+
+== Composition, its membership and participation in its meetings
+
+The selection of Advisory Group members will be in line with the document "`Guidelines for the establishment and functioning of Teams of Specialists`" (ECE.EX.2/Rev.1). The rules and principles of the following paragraphs will also be applied.
+
+The Advisory Group shall be composed of experts with the collective expertise to address the specific tasks defined for it. These should be drawn from
+
+. governmental institutions;
+
+. the business community;
+
+. civil society;
+
+. consumer organizations;
+
+. international organizations; and
+
+. academia.
+
+In order to be able to provide appropriate advice to UN/CEFACT and the UNECE secretariat, the membership of the Advisory Group should aim to include the following experts from the international supply chain:
+
+. Managers responsible for the implementation of such advanced technologies projects;
+
+. Senior government officials responsible for research and/or policies and regulations of such advanced technology implementations;
+
+. High-level academics and officials from non-governmental and other organizations (such as blockchain technology consortia and trade associations) who support work on blockchain and advanced technology implementations in trade logistics; and
+
+. Technical specialists.
+
+Participation in the Advisory Group will be on a voluntary basis. All members of the Advisory Group must register as experts of UN/CEFACT, in accordance with relevant procedures. All contributions to the work of the Advisory Group are in the context of the UN/CEFACT IPR Policy (ECE/TRADE/C/CEFACT/2010/20/Rev.2) and the Code of Conduct (ECE/TRADE/C/CEFACT/2010/18/Rev.1) and the overarching UN/CEFACT Mandate and Terms of Reference (ECE/TRADE/C/CEFACT/2017/15).
+
+The Advisory Group appoints its Chair in accordance with the Guidelines for the establishment and functioning of teams of specialists (UNECE ECE/EX/2/Rev.1).
+
+The Advisory Group will meet virtually at least once every two months and plan at least one face-to-face meeting per year.
+
+The UNECE secretariat provides necessary support to the Advisory Group within available resources.
+
+== Reporting
+
+The Advisory Group will report to the UN/CEFACT Plenary annually and will keep the UN/CEFACT Plenary Bureau informed of its activities.
+
+
+
+

--- a/sources/ECE_TRADE_C_CEFACT_2020_19E.adoc
+++ b/sources/ECE_TRADE_C_CEFACT_2020_19E.adoc
@@ -1,0 +1,84 @@
+= Report of the Advisory Group Advanced Technologies in Trade and Logistics on its First Annual Meeting
+:doctype: meeting-report
+:docnumber: GE.20-02503(E)
+:committee: Centre for Trade Facilitation and Electronic Business
+:status: published
+:copyright-year: 2020
+:session: 26
+:session-date: Geneva, 4-5 May 2020
+:item-number: 8 of the provisional agenda
+:agenda-id: ECE/TRADE/C/CEFACT/2020/19
+:item-name: Advisory Group on Advanced Technologies in Trade and Logistics
+:revdate: 18 February 2020
+:language: en
+:distribution: General
+:mn-document-class: un
+:mn-output-extensions: xml,html,doc,rxl
+:docfile: ECE_TRADE_C_CEFACT_2020_19E.adoc
+:local-cache-only:
+:data-uri-image:
+
+== Introduction and opening
+
+The United Nations Economic Commission for Europe (UNECE) Advisory Group (AG) on Advanced Technologies in Trade and Logistics held its first session on 30 January 2020.
+
+The session was attended by 80 delegates and experts representing national governmental agencies, international organizations, non-governmental organizations, academia and the private sector.
+
+Experts from the following UNECE member States were present: Belgium, Estonia, Germany, Italy, Israel, the Netherlands, the Russian Federation, Slovenia, Tajikistan and the United Kingdom of Great Britain and Northern Ireland. Delegates from the following countries outside the UNECE region also participated: Brazil, India, the Lao People's Democratic Republic, Nigeria and Senegal.
+
+Representatives of the International Telecommunication Union (ITU), the United Nations Conference on Trade and Development (UNCTAD), the United Nations World Food Programme (WFP), the World Trade Organization (WTO), United Nations Volunteers and the World Economic Forum (WEF) participated in the session.
+
+The UNECE Executive Secretary welcomed participants and underscored the potential importance of this group providing guidance on new technologies. She reminded attendees of the importance of the 2030 Sustainable Development Agenda and the need to ensure that the work of this group assists governments and organizations to implement the Sustainable Development Goals, leaving no one behind. She further underscored the potential influence that such technologies have for fraudulent activities, and that this Group should keep responsible application at the forefront of their work.
+
+The Ambassador of the Permanent Mission of the Republic of Estonia to the United Nations welcomed the participants and expressed appreciation for the timely creation of this Advisory Group to deal specifically with the use of new technologies in Trade and Logistics. The Public Sector should take a role in implementing technologies such as Artificial Intelligence (AI), and Estonia has set up a task force to study such use. The Estonian Parliament will use AI for more faithful transcriptions of sessions. The Government of Estonia has stimulated joint projects, both public and private, through match-making events and through encouraging the use of AI in the private sector. Estonia aims to be a major test bed of AI. This implies rethinking some public structures such as education to prepare tomorrow's leaders and technicians. Governments can take a major role in using such technologies to improve the conditions of its citizens.
+
+The United Nations Centre for Trade Facilitation and Electronic Business (UN/CEFACT) Chair welcomed the experts to the Advisory Group and reminded them of the historic role of UN/CEFACT in working on standards and guidance in this area. Indeed, UN/CEFACT has, over several decades, linked trade facilitation to trade and government partnerships and helped to move goods across borders more effectively. The Chair invited the experts to familiarize themselves with the work of UN/CEFACT and encouraged them to join.
+
+The Secretariat presented the agenda for the meeting. It was approved as proposed (Decision 1).
+
+The Secretariat announced that it had received a candidature for the chairmanship of the Group from the Italian delegation and a candidature for Vice Chair from the Slovenian delegation. The Advisory Group appointed by acclamation Mr. Quintarelli as Chair and Ms. Dokuzov as Vice Chair (Decision 2). The newly appointed Chair presided over the rest of the meeting.
+
+The keynote speaker from the University of Geneva, in their opening, underscored the difficulty of explaining new technologies to the general public and regulators. The evolution of Artificial Intelligence is happening very quickly -- but in specific locations and specific sectors. This makes it very difficult to regulate them. The scope can also be very different for each potential solution; it is therefore necessary to imagine what the future will be with transformative technologies. How do we find a balance and not over-regulate? Who will benefit from these technologies (e.g. civil society, citizens, government agencies, technical companies) and should these actors have a role in their regulation? What role can intergovernmental agencies play? The speaker reminded attendees that some of the pitfalls include the changing nature of transformative technologies and emphasized that any regulations need to be future-proof in order to remain relevant. Learning and monitoring will play a major role in the future.
+
+== The role of technology in reimagining future supply chains
+
+Representatives from other United Nations organizations, international bodies and the public sector were invited to present practical use cases of new technologies positively impacting Trade and Logistics, and to explain the benefits, implementation obstacles and lessons learned. Implementation will be a critical factor in the successful leveraging of new technologies.
+
+Attendees were reminded of the current state of Industry 4.0. Technologies formerly considered cutting edge, which have now become standard use (such as the use of cloud technology). Today, countries like Switzerland are working more and more to improve connectivity, especially for IoT devices. Implementation requires synergies between the readiness of the user community, the reliability of the technologies, the availability of data/standards, and the enabling infrastructure. IoT uses and the connection that these can have with blockchain technology were briefly presented.
+
+Four generations of blockchain/Distributed Ledger Technology (DLT) were presented: the first being Bitcoin; the second being Ethereum and smart contracts; the third being EOS, IOTA, Hyperledger increasing the capacity and speed of the blockchain network; and the fourth being Tolar HashNET, Hedera Hashgraph. Several use cases of blockchain technology were presented, notably the European Blockchain Services Infrastructure (EBSI) for notarization, identity framework, and data sharing. Other applications were presented for bonds, bookkeeping and auditing.
+
+Bridging supply-chain complexity and providing traceability can be achieved through advanced technologies, but generally a link may be missing between the physical product and its digital representation and corresponding data. In certain cases, linking digital technologies to the bio markers of the product, based on DNA technology, allows for the tracking of a product throughout its lifecycle. A bio marker allows the final product to be traced back, though each phase of its evolution, to its origins. Such bio markers can be applied to gems, precious metals, and natural or man-made textiles.
+
+Regarding data quality and security of data, attendees were reminded that there are positive approaches (which strive to achieve organizational goals and improve performance) and negative approaches (whose goal is protection from fraudulent activities). Within information security, there are three pillars: authentication (identify the origin of the transaction and only genuine parties have access); confidentiality (of all or part of the data); and integrity (to ensure that no one can contest the data). One approach to address this is the traditional PKI approach. Another is a blockchain approach, which is excellent for integrity but not necessarily for identity and not for confidentiality. There are advantages and disadvantages in both approaches. Solutions will generally require a combination of these technologies.
+
+Questions were raised about how to help developing/transitioning countries use these new technologies and how to ensure that these technologies are supporting the implementation of the 2030 Sustainable Development Goals. This topic should be kept in mind for the future work of the Advisory Group.
+
+== How to handle digital information and technologies for value chains
+
+Artificial Intelligence can also be used for border surveillance. AI can be faster but not necessarily smarter; it is therefore necessary to teach AI basic concepts for it to function. AI can be applied to trade and logistics at the border to identify potential fraud or to optimize circulation flows.
+
+We are experiencing a tsunami of data and only 1-2 per cent is being analysed. There are many challenges including multiple standards, fragmentation of platforms, natural languages / computer languages, and long investment return times. A global approach to data can identify the distribution of stored data—where it is being stored allowing for the identification of potential risks.
+
+A thirty-year World Economic Forum study involving Nordic countries showed that the use of standards results in a roughly 40 per cent increase in GDP. Standards enable increased interoperability, improved quality, better access to global markets and support for innovation. The International Telecommunication Union (ITU) has developed several infrastructure standards which enable the use of new technologies and ensure interoperability across borders.
+
+Data is continually generated with everyday use of devices such as smart phones or vehicles. Before 2001, this data was typically discarded; but since then, it has been increasingly valued and marketed. Each region of the world has different preoccupations. In many African countries, the tracking of physical assets, especially for perishable products, is a major challenge; technology has been key in improving this kind of tracking.
+
+== Obstacles, challenges and lessons learned
+
+Service providers are offering applications to their user communities to enhance their operations. However, the multiplication of providers requires underlying standards so that the applications can communicate with each other. The UN/CEFACT project on Smart Containers has responded to this need, providing a clear standard that any entity can use or reference. It is important that such standards are adaptable, can be used by different users in different ways, and support harmonization between applications—allowing for connectivity and interoperability. The UN/CEFACT Core Component Library footnote:[The United Nations Core Component Library (CCL) is a library of business semantics in a data model which is harmonized, audited and published by UN/CEFACT. Available at: https://www.unece.org/cefact/codesfortrade/unccl/ccl_index.html]  and the UN/CEFACT Multi-Modal Transport Reference Data Model footnote:[The UN/CEFACT Multi-Modal Transport Reference Data Model (MMT-RDM) is a subset of the Buy/Ship/Pay Reference Data Model covering contracts for the supply of transport and related services. Available at: https://www.unece.org/uncefact/mainstandards.html] are key examples of this. The next evolution of this will be to develop standardized Application Programming Interfaces (APIs) to allow web programmers to easily use the standards.
+
+Blockchain technologies have been applied to solutions for liquefied natural gas (LNG) by using tokens to generate additional revenue and contribute to positive social impact. The supply chain of LNG has been relatively unchanged for many years. Blockchain technology can reveal the inefficiencies and the lack of transparency in these value chains. Looking forward, it could be useful to use APIs in these exchanges for key resources such as the UN/LOCODE footnote:[The United Nations Code for Trade and Transport Locations (UN/LOCODE) is a geographic coding scheme developed and maintained by the United Nations Economic Commission for Europe (UNECE). Available at: https://www.unece.org/cefact/locode/service/location].
+
+The World Food Program has been developing a blockchain solution to allow 70 agencies to coordinate their information exchange for a transport corridor between Djibouti and Ethiopia. The time spent in document approvals and clearance will be reduced and there will be an increase in accountability of fleet operations. The blockchain-powered platform for the humanitarian supply chain currently provides real-time insights that mitigate issues regarding traceability, visibility, compliance and fleet management. Information is easily accessible and traceable, as records on the blockchain cannot be erased, thus allowing all actors to effectively collaborate and increase performance. In 2019, a proof of concept digital platform was developed. In 2020, the platform will be further developed to include new features and functionalities.
+
+Border crossing in transport can often involve several hours or days in border queues, resulting in lost revenue. Implementing an API-based virtual queue allows drivers to plan their border crossing, book a time for the crossing, arrive at the designated time and cross the border rapidly. This Just-In-Time cross-border logistics approach allows for better resource management and administration.
+
+== Next steps for the Advisory Group
+
+The draft Programme of Work—detailing the scope, objectives, activities, work areas, guiding principles, governance, and funding for the AG—was discussed, amended and approved. The draft vision and mission statements, summarizing the overall goals and methods by which to achieve them, were discussed, slightly amended and approved (Decision 3).
+
+It was suggested that the themes of identity, interoperability, security and trustworthiness be identified as key areas of work for future reflection. There was also a suggestion to put out a call for ideas that could be circulated and used as a future work area.
+
+Delegates and participants were invited to adopt the decisions of the session (Decision 4).
+


### PR DESCRIPTION
As requested in https://github.com/metanorma/mn-samples-un/issues/28

### Docs converted:
- 11 ECE_TRADE_C_CEFACT_2020_19E AGAT 1st meeting Report.docx (Meeting report)
- 11E ECE_TRADE_C_CEFACT_2019_22 ToR AG Technologies_Rev1.doc.docx (Terms of Reference)
- FINAL Provisional agenda - ECE_AGAT_2020_INF1.docx (Annotated provisional agenda)


***Comments on AGAT 1st meeting Report:***
- I set `meeting-report` as doctype.
- This doc doesn't have a summary, yet the title "Summary" is still shown in the front page of the generated file.

*Screenshot (generated front page):*
![generated-title](https://user-images.githubusercontent.com/33627611/79814078-5c25fa00-834b-11ea-9d08-f49f2468fd85.PNG)


***Comments on ToR AG Technologies_Rev1:***
- I set `terms-of-reference` as doctype.
- Bug detected. When a footnote is placed in the front page, a blank page is introduced between the front page and the main content. Ticket opened here: https://github.com/metanorma/metanorma-un/issues/53

***Comments on on ECE_AGAT_2020_INF1:***
- I set `agenda` as doctype.
- This document in particular, has two footnotes directly referenced in the main title:

*Screenshot (original source):*
![capture-title](https://user-images.githubusercontent.com/33627611/79813645-36e4bc00-834a-11ea-9d47-154a95e65376.PNG)

Footnotes don't work in that situation. I opened a ticket about it here: https://github.com/metanorma/metanorma-un/issues/54

Thanks!